### PR TITLE
[ODPR-1754] - Fix Warnings in the code

### DIFF
--- a/app/models/submission/Submission.scala
+++ b/app/models/submission/Submission.scala
@@ -139,7 +139,7 @@ object Submission {
     }
 
     private given OFormat[NotXml.type] = singletonOFormat(NotXml)
-    private given OFormat[SchemaValidationError.type] = singletonOFormat(SchemaValidationError)
+//    private given OFormat[SchemaValidationError.type] = singletonOFormat(SchemaValidationError)
     private given OFormat[ManualAssumedReportExists.type] = singletonOFormat(ManualAssumedReportExists)
     private given OFormat[PlatformOperatorIdMissing.type] = singletonOFormat(PlatformOperatorIdMissing)
     private given OFormat[PlatformOperatorIdMismatch] = Json.format

--- a/app/models/submission/Submission.scala
+++ b/app/models/submission/Submission.scala
@@ -139,7 +139,6 @@ object Submission {
     }
 
     private given OFormat[NotXml.type] = singletonOFormat(NotXml)
-//    private given OFormat[SchemaValidationError.type] = singletonOFormat(SchemaValidationError)
     private given OFormat[ManualAssumedReportExists.type] = singletonOFormat(ManualAssumedReportExists)
     private given OFormat[PlatformOperatorIdMissing.type] = singletonOFormat(PlatformOperatorIdMissing)
     private given OFormat[PlatformOperatorIdMismatch] = Json.format

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val microservice = (project in file("."))
     scalacOptions ++= Seq(
       "-no-indent",
       "-feature",
-      "-Wconf:cat=deprecation:w,cat=feature:w,src=target/.*:s"
+      "-Wconf:cat=deprecation:w,cat=feature:w,src=target/.*:s,msg=Flag.*repeatedly:s"
     ),
     libraryDependencies ++= AppDependencies(),
     retrieveManaged := true,

--- a/test/connectors/AssumedReportingConnectorSpec.scala
+++ b/test/connectors/AssumedReportingConnectorSpec.scala
@@ -17,9 +17,8 @@
 package connectors
 
 import base.SpecBase
-import connectors.AssumedReportingConnector.DeleteAssumedReportFailure
 
-class DeleteAssumedReportFailure extends SpecBase {
+class AssumedReportingConnectorSpec extends SpecBase {
   private val status = 503
   "DeleteAssumedReportFailure" - {
     "must contain correct message" in {


### PR DESCRIPTION
Supress the following sbt warnings:
[warn] Flag -deprecation set repeatedly
[warn] Flag -unchecked set repeatedly
[warn] Flag -encoding set repeatedly
using compilerOptions: "-Wconf:msg=Flag.*repeatedly:s"