### PR TITLE
DLS-12775|Jenkins date time format issue fixing with test cases

### DIFF
--- a/app/utils/DateTimeFormats.scala
+++ b/app/utils/DateTimeFormats.scala
@@ -21,6 +21,7 @@ import play.api.i18n.Lang
 import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder}
 import java.time.temporal.ChronoField
 import java.time.{Instant, ZoneId, ZoneOffset}
+import java.util
 import java.util.Locale
 
 object DateTimeFormats {
@@ -31,6 +32,14 @@ object DateTimeFormats {
     "en" -> dateTimeFormatter,
     "cy" -> dateTimeFormatter.withLocale(new Locale("cy"))
   )
+  private val lookup = new java.util.HashMap[java.lang.Long, String]()
+  lookup.put(0L, "am")
+  lookup.put(1L, "pm")
+
+  private val ukTimeZoneLookup = new util.HashMap[java.lang.Long, String]()
+  ukTimeZoneLookup.put(0L, "GMT")
+  ukTimeZoneLookup.put(3600L, "BST")
+
 
   def dateTimeFormat()(implicit lang: Lang): DateTimeFormatter = {
     localisedDateTimeFormatters.getOrElse(lang.code, dateTimeFormatter)
@@ -40,22 +49,16 @@ object DateTimeFormats {
     DateTimeFormatter.ofPattern("d M yyyy")
 
   val fullDateTimeFormatter: DateTimeFormatter = {
-
-    val lookup = new java.util.HashMap[java.lang.Long, String]()
-    lookup.put(0L, "am")
-    lookup.put(1L, "pm")
-
     new DateTimeFormatterBuilder()
       .appendPattern("h:mm")
       .appendText(ChronoField.AMPM_OF_DAY, lookup)
-      .appendPattern(" z 'on' d MMMM yyyy")
+      .appendLiteral(" ")
+      .appendText(ChronoField.OFFSET_SECONDS,ukTimeZoneLookup)
+      .appendPattern(" 'on' d MMMM yyyy")
       .toFormatter()
   }
 
   val EmailDateTimeFormatter: DateTimeFormatter = {
-    val lookup = new java.util.HashMap[java.lang.Long, String]()
-    lookup.put(0L, "am")
-    lookup.put(1L, "pm")
 
     DateTimeFormatterBuilder()
       .appendPattern("h:mm")
@@ -68,6 +71,10 @@ object DateTimeFormats {
   val dateTimeGmtFormatter = DateTimeFormatter.ofPattern("dd MMM yyyy HH:mm 'GMT'")
     
   def formatInstant(instant: Instant, formatter: DateTimeFormatter): String =
-    formatter.format(instant.atZone(ZoneOffset.UTC).withZoneSameInstant(ZoneId.of("Europe/London")))
+    {
+      formatter.format(instant.atZone(ZoneOffset.UTC).withZoneSameInstant(ZoneId.of("Europe/London")))
+    }
+
+
   
 }


### PR DESCRIPTION
This PR is to overcome the Jenkins unit test cases failure with date and time, 

Issue :
`[info] - must correctly format an instant during BST *** FAILED ***
[info]   "2:01pm [GMT+01:00] on 1 June 2024" did not equal "2:01pm [BST] on 1 June 2024" (DateTimeFormatsSpec.scala:73)
[info]   Analysis:
[info]   "2:01pm [GMT+01:00] on 1 June 2024" -> "2:01pm [BST] on 1 June 2024"`

Tested with changes and passed locally
<img width="480" height="210" alt="image" src="https://github.com/user-attachments/assets/68a46e67-ad1b-4b38-9e9b-08ca45895dcd" />


